### PR TITLE
3 network stalls during testing

### DIFF
--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/client/AbstractClientBase.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/client/AbstractClientBase.java
@@ -105,7 +105,7 @@ public abstract class AbstractClientBase {
 
       initFieldDefinition(definitionSupplier, masterNetwork);
     } catch (Exception e) {
-      logger.error("Error during handshake", e);
+      logger.error("C{}: Error during handshake", clientId, e);
       e.printStackTrace();
     }
   }

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/client/AbstractSessionEndPoint.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/client/AbstractSessionEndPoint.java
@@ -68,9 +68,9 @@ public abstract class AbstractSessionEndPoint<T extends ClientSession> implement
         // Bytes 0-3: client priority, assigned by server 1 (big endian int)
         // Bytes 4-7: unique id for client (big endian int)
         // Bytes 8-11: number of inputs (big endian int)
-        int priority = intFromBytes(Arrays.copyOfRange(handshakeMessage, 0, Integer.BYTES * 1));
+        int priority = intFromBytes(Arrays.copyOfRange(handshakeMessage, 0, Integer.BYTES));
         int clientId =
-                intFromBytes(Arrays.copyOfRange(handshakeMessage, Integer.BYTES * 1, Integer.BYTES * 2));
+                intFromBytes(Arrays.copyOfRange(handshakeMessage, Integer.BYTES, Integer.BYTES * 2));
         int numInputs =
                 intFromBytes(Arrays.copyOfRange(handshakeMessage, Integer.BYTES * 2, Integer.BYTES * 3));
         return registerNewSessionRequest(priority, clientId, numInputs, network);

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/client/OutputClient.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/client/OutputClient.java
@@ -2,7 +2,6 @@ package dk.alexandra.fresco.outsourcing.client;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.concurrent.Future;
 
 /**
  * The client side of an output procedure.

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/client/ddnnt/TripleDistributor.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/client/ddnnt/TripleDistributor.java
@@ -26,6 +26,6 @@ public interface TripleDistributor {
    * @param amount the amount of triples in the batch
    * @return a batch of triples.
    */
-  public List<DdnntInputTuple> getTriples(int amount);
+  List<DdnntInputTuple> getTriples(int amount);
 
 }

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/client/jno/ClientPayload.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/client/jno/ClientPayload.java
@@ -39,12 +39,12 @@ public class ClientPayload<T> {
     return x;
   }
 
-  public static <T> ClientPayload deserialize(ByteSerializer<T> serializer, byte[] t, byte[] k, byte[] r, byte[] xList) {
+  public static <T> ClientPayload<T> deserialize(ByteSerializer<T> serializer, byte[] t, byte[] k, byte[] r, byte[] xList) {
     T deserializedT = serializer.deserialize(t);
     T deserializedK = serializer.deserialize(k);
     T deserializedR = serializer.deserialize(r);
     List<T> deserializedX = serializer.deserializeList(xList);
-    return new ClientPayload(deserializedT, deserializedK, deserializedR, deserializedX);
+    return new ClientPayload<>(deserializedT, deserializedK, deserializedR, deserializedX);
   }
 
 

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/network/ClientSideNetworkFactory.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/network/ClientSideNetworkFactory.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 public class ClientSideNetworkFactory {
 
-  public static enum Parties {
+  public enum Parties {
     SERVER(2), CLIENT(1);
 
     private final int id;
@@ -48,8 +48,7 @@ public class ClientSideNetworkFactory {
     NetworkConfiguration conf = new NetworkConfigurationImpl(id, parties);
     NetworkConnector connector = new OutsourcingConnector(conf, Duration.ofDays(1));
     SocketNetwork network = new SocketNetwork(conf, connector.getSocketMap());
-    TwoPartyNetwork networkWrapper = new TwoPartyNetworkImpl(network, conf.getMyId());
-    return networkWrapper;
+    return new TwoPartyNetworkImpl(network, conf.getMyId());
   }
 
 }

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/network/OutsourcingConnector.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/network/OutsourcingConnector.java
@@ -141,7 +141,7 @@ public class OutsourcingConnector implements NetworkConnector {
           }
           // A connect exception is expected if the opposing side is not listening for our
           // connection attempt yet. We ignore this and try again.
-          Thread.sleep(1 << ++attempts);
+          Thread.sleep(1L << ++attempts);
         }
       }
     }

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/server/DemoClientSessionRequestHandler.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/server/DemoClientSessionRequestHandler.java
@@ -119,7 +119,7 @@ public class DemoClientSessionRequestHandler<T extends ClientSession, K extends 
    * Gets client ID from handshake.
    */
   private int getClientId(byte[] introBytes) {
-    return intFromBytes(Arrays.copyOfRange(introBytes, Integer.BYTES * 1, Integer.BYTES * 2));
+    return intFromBytes(Arrays.copyOfRange(introBytes, Integer.BYTES, Integer.BYTES * 2));
   }
 
   @Override

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/DdnntInputTuple.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/DdnntInputTuple.java
@@ -2,7 +2,6 @@ package dk.alexandra.fresco.outsourcing.server.ddnnt;
 
 import dk.alexandra.fresco.framework.builder.numeric.field.FieldElement;
 import dk.alexandra.fresco.framework.value.SInt;
-import java.math.BigInteger;
 
 /**
  * An input tuple as used in the DDNNT protocol.

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/DemoServerSessionProducer.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/DemoServerSessionProducer.java
@@ -27,8 +27,8 @@ public class DemoServerSessionProducer implements ServerSessionProducer<SpdzReso
 
   public static final int DEFAULT_BATCH_SIZE = 10000;
   private final int batchSize;
-  private SpdzResourcePool resourcePool;
-  private NetworkConfiguration conf;
+  private final SpdzResourcePool resourcePool;
+  private final NetworkConfiguration conf;
 
   /**
    * Creates a new server session producer with a given batch size, resource pool and network

--- a/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/SpdzDdnntTuple.java
+++ b/core/src/main/java/dk/alexandra/fresco/outsourcing/server/ddnnt/SpdzDdnntTuple.java
@@ -1,10 +1,9 @@
 package dk.alexandra.fresco.outsourcing.server.ddnnt;
 
-import dk.alexandra.fresco.framework.builder.numeric.field.FieldDefinition;
 import dk.alexandra.fresco.framework.builder.numeric.field.FieldElement;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.suite.spdz.datatypes.SpdzTriple;
-import java.math.BigInteger;
+
 import java.util.Objects;
 
 /**

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -70,12 +71,14 @@ public abstract class GenericInputServerTest {
 
   @Test
   public void testManyClients() throws Exception {
+    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
     setTestRunner(10, 20, 3);
     testInputsOnly();
   }
 
   @Test
   public void testManyServers() throws Exception {
+    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
     setTestRunner(10, 10, 9);
     testInputsOnly();
   }

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
@@ -70,15 +70,15 @@ public abstract class GenericInputServerTest {
   }
 
   @Test
+  @Ignore // Can't run in the suite since too many threads open up
   public void testManyClients() throws Exception {
-    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
     setTestRunner(10, 20, 3);
     testInputsOnly();
   }
 
   @Test
+  @Ignore // Can't run in the suite since too many threads open up
   public void testManyServers() throws Exception {
-    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
     setTestRunner(10, 10, 9);
     testInputsOnly();
   }

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericInputServerTest.java
@@ -16,6 +16,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
@@ -6,7 +6,6 @@ import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.outsourcing.client.OutputClient;
 import dk.alexandra.fresco.outsourcing.setup.SpdzSetup;
 import dk.alexandra.fresco.outsourcing.setup.SpdzWithIO;
-import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
@@ -6,6 +6,7 @@ import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.outsourcing.client.OutputClient;
 import dk.alexandra.fresco.outsourcing.setup.SpdzSetup;
 import dk.alexandra.fresco.outsourcing.setup.SpdzWithIO;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigInteger;

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
@@ -83,8 +83,8 @@ public abstract class GenericOutputServerTest {
   }
 
   @Test
+  @Ignore // Can't run in the suite since too many threads open up
   public void testManyServers() throws Exception {
-    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
 
     setTestRunner(10, 3, 10);
     testClientOutput();

--- a/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
+++ b/core/src/test/java/dk/alexandra/fresco/outsourcing/server/GenericOutputServerTest.java
@@ -6,6 +6,7 @@ import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.outsourcing.client.OutputClient;
 import dk.alexandra.fresco.outsourcing.setup.SpdzSetup;
 import dk.alexandra.fresco.outsourcing.setup.SpdzWithIO;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -83,6 +84,8 @@ public abstract class GenericOutputServerTest {
 
   @Test
   public void testManyServers() throws Exception {
+    Assume.assumeTrue("Too many threads running, skipping", java.lang.Thread.activeCount() < 1000);
+
     setTestRunner(10, 3, 10);
     testClientOutput();
   }

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/Benchmarkable.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/Benchmarkable.java
@@ -1,8 +1,8 @@
 package dk.alexandra.fresco.outsourcing.benchmark;
 
 public interface Benchmarkable {
-  public void setup();
-  public void beforeEach();
-  public void run(Hole blackhole);
-  public void afterEach();
+  void setup();
+  void beforeEach();
+  void run(Hole blackhole);
+  void afterEach();
 }

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/ClientPPP.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/ClientPPP.java
@@ -21,9 +21,9 @@ public class ClientPPP extends PPP {
   private int currentBasePort;
 
   private List<Party> servers;
-  private List<BigInteger> clientInputs;
+  private final List<BigInteger> clientInputs;
   private OutputClient outputClient;
-  private int amountOfServers;
+  private final int amountOfServers;
   private final Drbg drbg;
 
   public ClientPPP(Map<Integer, String> serverIdIpMap, int inputs, int bitLength, int basePort) {

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/Hole.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/Hole.java
@@ -11,6 +11,6 @@ public class Hole {
 
   public void consume(Object x) {
     String something = "something " + x.toString();
-    System.out.println(something.toString());
+    System.out.println(something);
   }
 }

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/Interpolate.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/Interpolate.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class Interpolate implements Computation<SInt, ProtocolBuilderNumeric> {
 
-  private List<DRes<SInt>> points;
+  private final List<DRes<SInt>> points;
 
   public Interpolate(List<DRes<SInt>> points) {
     this.points = points;

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/Range.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/Range.java
@@ -5,7 +5,7 @@ import dk.alexandra.fresco.framework.builder.Computation;
 import dk.alexandra.fresco.framework.builder.numeric.ProtocolBuilderNumeric;
 import dk.alexandra.fresco.framework.value.SInt;
 import dk.alexandra.fresco.lib.common.compare.Comparison;
-import dk.alexandra.fresco.lib.common.compare.Comparison.Algorithm;
+
 import java.util.Arrays;
 
 public class Range implements Computation<SInt, ProtocolBuilderNumeric> {

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/RangeServer.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/RangeServer.java
@@ -61,7 +61,7 @@ public class RangeServer extends ServerPPP  {
         DRes<SInt> comparisonRes = seq.seq(
             new Range(hiddenLower, hiddenUpper, attributes.get(0), maxBitlength));
         return seq.seq((seq2) -> {
-          if (checkAtt.out() != true) {
+          if (!checkAtt.out()) {
             throw new IllegalArgumentException("Invalid user MAC");
           }
           return seq2.numeric().open(comparisonRes);

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameObject.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameObject.java
@@ -11,9 +11,9 @@ import java.util.List;
 
 public class SameObject implements Computation<SInt, ProtocolBuilderNumeric> {
 
-  private List<DRes<SInt>> clientsInputs;
-  private List<DRes<SInt>> referenceVals;
-  private int bitlength;
+  private final List<DRes<SInt>> clientsInputs;
+  private final List<DRes<SInt>> referenceVals;
+  private final int bitlength;
 
   public SameObject(List<DRes<SInt>> referenceVals, List<DRes<SInt>> clientsInputs, int bitlength) {
     this.clientsInputs = clientsInputs;

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameObjectServer.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameObjectServer.java
@@ -77,7 +77,7 @@ public class SameObjectServer extends ServerPPP {
         DRes<SInt> comparisonRes = seq.seq(
             new SameObject(refValues, attributes.subList(0, amountOfElements), bitLength));
         return seq.seq((seq2) -> {
-          if (checkAtt.out() != true) {
+          if (!checkAtt.out()) {
             throw new IllegalArgumentException("Invalid user MAC");
           }
           return seq2.numeric().open(comparisonRes.out());

--- a/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameValue.java
+++ b/demo/src/main/java/dk/alexandra/fresco/outsourcing/benchmark/applications/SameValue.java
@@ -8,8 +8,8 @@ import dk.alexandra.fresco.lib.common.compare.Comparison;
 
 public class SameValue implements Computation<SInt, ProtocolBuilderNumeric> {
 
-  private DRes<SInt> clientsInput;
-  private DRes<SInt> referenceVal;
+  private final DRes<SInt> clientsInput;
+  private final DRes<SInt> referenceVal;
 
   public SameValue(DRes<SInt> referenceVal, DRes<SInt> clientsInput) {
     this.clientsInput = clientsInput;

--- a/demo/src/test/java/dk/alexandra/fresco/outsourcing/benchmark/ApplicationTests.java
+++ b/demo/src/test/java/dk/alexandra/fresco/outsourcing/benchmark/ApplicationTests.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 public class ApplicationTests extends AbstractDummyArithmeticTest {
 
-  private static TestParameters params = new TestParameters().
+  private static final TestParameters params = new TestParameters().
       numParties(3).
       maxBitLength(96).
       evaluationStrategy(SEQUENTIAL_BATCHED).


### PR DESCRIPTION
Code cleanup and disabling of high-load tests, which were spawning way too many threads thus crashing.

The tests work fine when ran alone, but due to some JUnit probably reusing the process and not killing all threads before hand, the tests alone could spawn in the neighbourhood of ~750 threads, since each client/server has two threads for each connection.

Code cleanup is simply some suggestions applied from the linter.